### PR TITLE
Add message form test

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -14,6 +14,7 @@ class Message
   sig { void }
   def send
     mg_client = Mailgun::Client.new ENV['mailgun_secret_api_key']
+    mg_client.enable_test_mode! if Rails.env.test?
     info = {
       from: email,
       to: 'alan@alanvardy.com',

--- a/test/system/message_test.rb
+++ b/test/system/message_test.rb
@@ -1,0 +1,22 @@
+require 'application_system_test_case'
+
+class NavigationTest < ApplicationSystemTestCase
+  def setup
+    @name = 'Test'
+    @email = 'test@test.com'
+    @phone = '123 456-7890'
+    @message = "I'm making a note here: 'HUGE SUCCESS!'"
+  end
+
+  test 'can send an email' do
+    visit root_url
+    click_link 'Contact Me'
+    sleep 1
+    fill_in 'message_name', with: @name
+    fill_in 'message_email', with: @email
+    fill_in 'message_phone_number', with: @phone
+    fill_in 'message_body', with: @message
+    click_button 'Send Form'
+    assert_content 'received'
+  end
+end


### PR DESCRIPTION
Closes #407 
Added a check for test environment in message model and enabled test mode for mailgun if true. Acceptance test can now fill and submit the form without shooting off an actual email.